### PR TITLE
Update README and clean up code comments

### DIFF
--- a/create_hpo_pipline.py
+++ b/create_hpo_pipline.py
@@ -1,4 +1,3 @@
-# FILE: create_hpo_pipeline.py
 """
 Creates a Vertex AI Pipeline to run a Hyperparameter Tuning job.
 """
@@ -80,5 +79,4 @@ if __name__ == "__main__":
     compiler.Compiler().compile(
         pipeline_func=hpo_pipeline,
         package_path="hpo_pipeline.json",
-    )
-    print("✓ Compiled hpo_pipeline.json")
+    )    print("✓ Compiled hpo_pipeline.json")

--- a/create_inference_pipeline.py
+++ b/create_inference_pipeline.py
@@ -1,0 +1,81 @@
+"""Compile the daily batch inference pipeline for Vertex AI."""
+
+from kfp import dsl, compiler
+from google_cloud_pipeline_components.v1.bigquery import BigqueryQueryJobOp
+from google_cloud_pipeline_components.v1.batch_predict_job import ModelBatchPredictOp
+from google_cloud_pipeline_components.types import artifact_types
+
+# ───── constants ─────
+PROJECT_ID   = "profitscout-lx6bb"
+REGION       = "us-central1"
+PIPE_ROOT    = "gs://profit-scout-pipeline-artifacts/pipeline-root"
+
+DATASET      = "profit_scout"
+FEATURES_TBL = f"{DATASET}.breakout_features"
+INPUT_TBL_ID = "daily_prediction_input"
+INPUT_TBL    = f"{PROJECT_ID}.{DATASET}.{INPUT_TBL_ID}"
+OUTPUT_DATASET_URI = f"bq://{PROJECT_ID}.{DATASET}"
+MODEL_ID     = "profitscout-xgboost-classifier@default"   # registry alias
+
+# ───── pipeline ─────
+@dsl.pipeline(
+    name="profitscout-daily-batch-inference",
+    pipeline_root=PIPE_ROOT,
+    description="Queries new rows and runs Vertex AI BatchPredict.",
+)
+def daily_inference_pipeline(
+    project: str = PROJECT_ID,
+    location: str = REGION,
+):
+    """Queries new rows then performs batch predictions."""
+
+    # 1️⃣ filter new rows → BigQuery
+    BigqueryQueryJobOp(
+        project  = project,
+        location = location,
+        query = f"""
+          SELECT *
+          FROM `{project}.{FEATURES_TBL}`
+          WHERE max_close_30d IS NULL
+        """,
+        job_configuration_query = {
+            "destinationTable": {
+                "projectId": project,
+                "datasetId": DATASET,
+                "tableId"  : INPUT_TBL_ID,
+            },
+            "writeDisposition": "WRITE_TRUNCATE",
+        },
+    )
+
+    # 2️⃣ importer node converts the registry model to a VertexModel artifact
+    model_artifact = dsl.importer(
+        artifact_uri = (
+            f"https://{location}-aiplatform.googleapis.com/v1/"
+            f"projects/{project}/locations/{location}/models/{MODEL_ID}"
+        ),
+        artifact_class = artifact_types.VertexModel,
+        metadata = {"resourceName":
+            f"projects/{project}/locations/{location}/models/{MODEL_ID}"}
+    )
+
+    # 3️⃣ batch prediction
+    ModelBatchPredictOp(
+        project                         = project,
+        location                        = location,
+        job_display_name                = "daily-profitscout-batch-prediction",
+        model                           = model_artifact.outputs["artifact"], # use artifact
+        instances_format                = "bigquery",
+        predictions_format              = "bigquery",
+        bigquery_source_input_uri       = INPUT_TBL,
+        bigquery_destination_output_uri = OUTPUT_DATASET_URI,
+        machine_type                    = "n1-standard-4",
+    )
+
+# ───── compile ─────
+if __name__ == "__main__":
+    compiler.Compiler().compile(
+        pipeline_func = daily_inference_pipeline,
+        package_path  = "daily_inference_pipeline.json",
+    )
+    print("✓ Compiled daily_inference_pipeline.json")

--- a/create_training_pipeline.py
+++ b/create_training_pipeline.py
@@ -1,0 +1,96 @@
+"""
+create_training_pipeline.py
+Author: ProfitScout ML Engineering
+Description:
+  • Trains the XGBoost classifier weekly on Vertex AI
+  • Imports the unmanaged model artifact from GCS
+  • Uploads / registers the model in Vertex AI Model Registry
+"""
+
+# ───────────────────────── Imports ─────────────────────────
+import os
+from kfp import dsl, compiler
+from kfp.dsl import importer                                # universal importer
+from google_cloud_pipeline_components.types import artifact_types
+from google_cloud_pipeline_components.v1.custom_job import CustomTrainingJobOp
+from google_cloud_pipeline_components.v1.model import ModelUploadOp
+
+# ──────────────────── Configurable constants ──────────────
+PROJECT_ID        = "profitscout-lx6bb"
+REGION            = "us-central1"
+PIPELINE_ROOT     = "gs://profit-scout-pipeline-artifacts/pipeline-root"
+
+# container image that runs training
+TRAINER_IMAGE_URI = (
+    "us-central1-docker.pkg.dev/profitscout-lx6bb/"
+    "profit-scout-repo/trainer:latest"
+)
+
+MODEL_DISPLAY_NAME = "profitscout-xgboost-classifier"
+
+# one canonical folder where every run puts its model artefacts
+MODEL_DIR = f"{PIPELINE_ROOT}/models"
+
+# ───────────────────────── Pipeline ────────────────────────
+@dsl.pipeline(
+    name="weekly-training-and-register-pipeline",
+    description="Train and register the ProfitScout model weekly.",
+    pipeline_root=PIPELINE_ROOT,
+)
+def weekly_training_pipeline(
+    project: str = PROJECT_ID,
+    location: str = REGION,
+    model_display_name: str = MODEL_DISPLAY_NAME,
+    source_table: str = "profit_scout.breakout_features",
+    metadata_table: str = "profit_scout.stock_metadata",
+):
+    """Weekly training + registration workflow."""
+
+    # 1️⃣ Custom Training Job spec (Vertex AI Training)
+    worker_pool_specs = [{
+        "machine_spec": {"machine_type": "n1-standard-4"},
+        "replica_count": 1,
+        "container_spec": {
+            "image_uri": TRAINER_IMAGE_URI,
+            "args": [
+                f"--source-table={source_table}",
+                f"--metadata-table={metadata_table}",
+            ],
+            # Explicitly point the trainer to the folder Vertex AI will sync
+            "env": [{"name": "AIP_MODEL_DIR", "value": MODEL_DIR}],
+        },
+    }]
+
+    train_job = CustomTrainingJobOp(
+        display_name="weekly-profitscout-training-job",
+        project=project,
+        location=location,
+        worker_pool_specs=worker_pool_specs,
+        base_output_directory=MODEL_DIR,  # Vertex AI copies $AIP_MODEL_DIR → here
+    )
+
+    # 2️⃣ Import the model artefact produced by the training container
+    model_artifact = importer(
+        artifact_uri=MODEL_DIR,
+        artifact_class=artifact_types.UnmanagedContainerModel,
+        metadata={"containerSpec": {"imageUri": TRAINER_IMAGE_URI}},
+    )
+
+    # 3️⃣ Upload / register the imported model
+    upload_job = ModelUploadOp(
+        display_name=model_display_name,
+        project=project,
+        location=location,
+        unmanaged_container_model=model_artifact.output,
+    )
+
+    # Ensure upload runs after training
+    upload_job.after(train_job)
+
+# ───────────────────────── Compile ─────────────────────────
+if __name__ == "__main__":
+    compiler.Compiler().compile(
+        pipeline_func=weekly_training_pipeline,
+        package_path="weekly_training_pipeline.json",
+    )
+    print("✓ Compiled weekly_training_pipeline.json")

--- a/discovery/main.py
+++ b/discovery/main.py
@@ -1,3 +1,5 @@
+"""Cloud Function to publish Pub/Sub messages for new transcripts."""
+
 import os
 import logging
 import json
@@ -55,5 +57,4 @@ def discover_new_summary(event, context):
         logging.error(f"Could not parse ticker and date from filename: '{file_name}'. Error: {e}")
     except Exception as e:
         logging.error(f"An unexpected error occurred processing file {file_name}: {e}")
-
     return 'OK', 200

--- a/feature_engineering/main.py
+++ b/feature_engineering/main.py
@@ -1,4 +1,4 @@
-#feature_engineering/main.py
+"""Cloud Run service that generates features from transcript events."""
 
 import os
 import json
@@ -56,5 +56,4 @@ def process_pubsub_message():
         return 'Internal Server Error', 500
 
 if __name__ == '__main__':
-    PORT = int(os.environ.get('PORT', 8080))
-    app.run(host='0.0.0.0', port=PORT, debug=True)
+    PORT = int(os.environ.get('PORT', 8080))    app.run(host='0.0.0.0', port=PORT, debug=True)

--- a/feature_engineering/utils/bq.py
+++ b/feature_engineering/utils/bq.py
@@ -15,8 +15,7 @@ def _format_value(value):
     if isinstance(value, list):
         return f"[{','.join(map(str, value))}]"
     
-    # FIX: This now handles both date and datetime strings correctly.
-    # It extracts only the date portion from the string before casting.
+    # Handle both date and datetime strings by casting the date portion.
     if isinstance(value, str) and re.match(r'^\d{4}-\d{2}-\d{2}', value):
         # Take only the date part of the string (e.g., '2025-05-01')
         date_part = value.split(' ')[0]
@@ -64,5 +63,4 @@ def upsert_row(row: dict, table_id: str, primary_keys: list):
         logging.error(f"BigQuery upsert failed: {e}")
         logging.error(f"Failed query: {query}")
         safe_row = {k: (type(v).__name__ if isinstance(v, list) else v) for k, v in row.items()}
-        logging.error(f"Row data (types simplified): {safe_row}")
-        raise
+        logging.error(f"Row data (types simplified): {safe_row}")        raise

--- a/feature_engineering/utils/processing.py
+++ b/feature_engineering/utils/processing.py
@@ -312,5 +312,4 @@ def create_features(message: dict) -> dict | None:
     if not {"earnings_call_date", "sentiment_score"}.issubset(row):
         logging.error(f"Failed to generate critical features for {ticker}. Aborting row.")
         return None
-
     return row

--- a/loader/main.py
+++ b/loader/main.py
@@ -1,4 +1,4 @@
-# loader/main.py
+"""Cloud Run service to stream processed features into BigQuery."""
 
 import os
 import json
@@ -70,5 +70,4 @@ def load_batch_to_bq():
         return "Internal Server Error", 500
 
 if __name__ == '__main__':
-    PORT = int(os.environ.get('PORT', 8080))
-    app.run(host='0.0.0.0', port=PORT, debug=True)
+    PORT = int(os.environ.get('PORT', 8080))    app.run(host='0.0.0.0', port=PORT, debug=True)

--- a/merger/main.py
+++ b/merger/main.py
@@ -1,4 +1,4 @@
-# FILE: merger/main.py
+"""Scheduled function to merge staging data into the final BigQuery table."""
 
 import os
 import logging
@@ -131,5 +131,4 @@ def merge_staging_to_final(event, context):
 
         return "Merge completed successfully", 200
     except Exception as e:
-        logging.error(f"Merge process failed: {e}", exc_info=True)
-        return "Merge process failed", 500
+        logging.error(f"Merge process failed: {e}", exc_info=True)        return "Merge process failed", 500

--- a/predictor/main.py
+++ b/predictor/main.py
@@ -195,5 +195,4 @@ def main():
     save_predictions(df_results, args.project_id, args.destination_table)
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":    main()

--- a/trainer/main.py
+++ b/trainer/main.py
@@ -218,5 +218,4 @@ def main():
     
     logging.info("Training run complete.")
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":    main()


### PR DESCRIPTION
## Summary
- clarify setup instructions and remove noisy comments
- restore training and inference pipeline scripts
- clean up stray header comments and ensure files end with newlines
- add module-level docstrings for service scripts and pipelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d53267abc8331b9c7261c88ed9c37